### PR TITLE
Implement wildcard support for ls command

### DIFF
--- a/ls.c
+++ b/ls.c
@@ -3,6 +3,38 @@
 #include "user.h"
 #include "fs.h"
 
+static int
+has_wildcard(const char *s)
+{
+  for(; *s; s++)
+    if(*s == '*')
+      return 1;
+  return 0;
+}
+
+static int
+match(const char *name, const char *pattern)
+{
+  while(*pattern){
+    if(*pattern == '*'){
+      pattern++;
+      if(*pattern == 0)
+        return 1;
+      while(*name){
+        if(match(name, pattern))
+          return 1;
+        name++;
+      }
+      return 0;
+    }
+    if(*name != *pattern)
+      return 0;
+    name++;
+    pattern++;
+  }
+  return *name == 0;
+}
+
 char*
 fmtname(char *path)
 {
@@ -29,6 +61,89 @@ ls(char *path)
   int fd;
   struct dirent de;
   struct stat st;
+
+  // Handle simple wildcard patterns like "*.c" or "dir/*.c"
+  if(has_wildcard(path)){
+    char dir[512];
+    char pattern[512];
+    char *q;
+
+    // Find first character after last slash (directory separator)
+    for(q = path + strlen(path); q >= path && *q != '/'; q--)
+      ;
+    q++;  // q now points to the start of the last path component (pattern)
+
+    if(q == path){
+      // No slash in path; use current directory
+      strcpy(dir, ".");
+    } else {
+      int dirlen = q - path - 1; // exclude the '/'
+      if(dirlen == 0 && path[0] == '/'){
+        // pattern like "/*.c" -> directory is "/"
+        strcpy(dir, "/");
+      } else {
+        if(dirlen >= sizeof(dir)){
+          printf(1, "ls: path too long\n");
+          return;
+        }
+        memmove(dir, path, dirlen);
+        dir[dirlen] = 0;
+      }
+    }
+
+    if(strlen(q) >= sizeof(pattern)){
+      printf(1, "ls: path too long\n");
+      return;
+    }
+    strcpy(pattern, q);
+
+    if((fd = open(dir, 0)) < 0){
+      printf(2, "ls: cannot open %s\n", dir);
+      return;
+    }
+
+    if(fstat(fd, &st) < 0){
+      printf(2, "ls: cannot stat %s\n", dir);
+      close(fd);
+      return;
+    }
+
+    if(st.type != T_DIR){
+      printf(1, "ls: not a directory %s\n", dir);
+      close(fd);
+      return;
+    }
+
+    if(strlen(dir) + 1 + DIRSIZ + 1 > sizeof buf){
+      printf(1, "ls: path too long\n");
+      close(fd);
+      return;
+    }
+
+    strcpy(buf, dir);
+    p = buf+strlen(buf);
+    *p++ = '/';
+    while(read(fd, &de, sizeof(de)) == sizeof(de)){
+      if(de.inum == 0)
+        continue;
+
+      char namebuf[DIRSIZ+1];
+      memmove(namebuf, de.name, DIRSIZ);
+      namebuf[DIRSIZ] = 0;
+      if(!match(namebuf, pattern))
+        continue;
+
+      memmove(p, de.name, DIRSIZ);
+      p[DIRSIZ] = 0;
+      if(stat(buf, &st) < 0){
+        printf(1, "ls: cannot stat %s\n", buf);
+        continue;
+      }
+      printf(1, "%s %d %d %d\n", fmtname(buf), st.type, st.ino, st.size);
+    }
+    close(fd);
+    return;
+  }
 
   if((fd = open(path, 0)) < 0){
     printf(2, "ls: cannot open %s\n", path);


### PR DESCRIPTION
Add wildcard support to the `ls` command to enable filtering files by patterns like `*.c`.

---
<a href="https://cursor.com/background-agent?bcId=bc-218fe9eb-39ae-47f6-946a-954c9566b716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-218fe9eb-39ae-47f6-946a-954c9566b716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

