### PR TITLE
Implement wildcard support for ls command

### DIFF
--- a/ls.c
+++ b/ls.c
@@ -3,6 +3,52 @@
 #include "user.h"
 #include "fs.h"
 
+// Simple '*' wildcard matcher: '*' matches any sequence (including empty)
+static int
+match_pattern(const char *pattern, const char *text)
+{
+  // If we've reached the end of the pattern, it matches only if text also ended
+  if(*pattern == 0)
+    return *text == 0;
+
+  if(*pattern == '*'){
+    // Skip consecutive '*'
+    while(*pattern == '*')
+      pattern++;
+    // If pattern ends with '*', it matches the rest of text
+    if(*pattern == 0)
+      return 1;
+    // Try to match the remainder of pattern at every position in text
+    for(; *text; text++){
+      if(match_pattern(pattern, text))
+        return 1;
+    }
+    // Also try empty match against end of text
+    return match_pattern(pattern, text);
+  }
+
+  // Regular character must match exactly
+  if(*text && *pattern == *text)
+    return match_pattern(pattern+1, text+1);
+
+  return 0;
+}
+
+static int
+has_star_in_last_component(const char *path)
+{
+  const char *lastslash = 0;
+  const char *s;
+  for(s = path; *s; s++)
+    if(*s == '/')
+      lastslash = s;
+  const char *last = lastslash ? lastslash + 1 : path;
+  for(; *last; last++)
+    if(*last == '*')
+      return 1;
+  return 0;
+}
+
 char*
 fmtname(char *path)
 {
@@ -29,6 +75,75 @@ ls(char *path)
   int fd;
   struct dirent de;
   struct stat st;
+
+  // Handle wildcard in the last path component by expanding within its directory
+  if(has_star_in_last_component(path)){
+    char dir[512];
+    const char *s;
+    const char *lastslash = 0;
+    for(s = path; *s; s++)
+      if(*s == '/')
+        lastslash = s;
+
+    const char *pattern = lastslash ? lastslash + 1 : path;
+
+    if(lastslash){
+      int dlen = lastslash - path;
+      if(dlen >= sizeof(dir)){
+        printf(1, "ls: path too long\n");
+        return;
+      }
+      memmove(dir, path, dlen);
+      dir[dlen] = 0;
+    } else {
+      dir[0] = '.';
+      dir[1] = 0;
+    }
+
+    if((fd = open(dir, 0)) < 0){
+      printf(2, "ls: cannot open %s\n", dir);
+      return;
+    }
+    if(fstat(fd, &st) < 0){
+      printf(2, "ls: cannot stat %s\n", dir);
+      close(fd);
+      return;
+    }
+    if(st.type != T_DIR){
+      // Parent is not a directory; nothing to expand
+      close(fd);
+      return;
+    }
+
+    if(strlen(dir) + 1 + DIRSIZ + 1 > sizeof buf){
+      printf(1, "ls: path too long\n");
+      close(fd);
+      return;
+    }
+    strcpy(buf, dir);
+    p = buf + strlen(buf);
+    *p++ = '/';
+    while(read(fd, &de, sizeof(de)) == sizeof(de)){
+      if(de.inum == 0)
+        continue;
+
+      char name[DIRSIZ+1];
+      memmove(name, de.name, DIRSIZ);
+      name[DIRSIZ] = 0;
+      if(!match_pattern(pattern, name))
+        continue;
+
+      memmove(p, de.name, DIRSIZ);
+      p[DIRSIZ] = 0;
+      if(stat(buf, &st) < 0){
+        printf(1, "ls: cannot stat %s\n", buf);
+        continue;
+      }
+      printf(1, "%s %d %d %d\n", fmtname(buf), st.type, st.ino, st.size);
+    }
+    close(fd);
+    return;
+  }
 
   if((fd = open(path, 0)) < 0){
     printf(2, "ls: cannot open %s\n", path);


### PR DESCRIPTION
Add `*` wildcard support to the `ls` command to enable pattern matching for filenames.

This change allows `ls` to expand patterns containing `*` in the last path component, such as `ls *.c`, `ls a*`, or `ls dir/*.c`. Only the `*` wildcard is supported (no `?` or character sets).

---
<a href="https://cursor.com/background-agent?bcId=bc-ce53c4a5-8e3d-426d-a006-947a7dabb2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce53c4a5-8e3d-426d-a006-947a7dabb2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

